### PR TITLE
Delete IC Device Copy Ctors & Copy Assign Ops

### DIFF
--- a/code/source/i2c/ADS1015Controller.hpp
+++ b/code/source/i2c/ADS1015Controller.hpp
@@ -169,6 +169,10 @@ public:
 	// }
 
 private:
+	ADS1015Controller( const ADS1015Controller& ) = delete;
+	ADS1015Controller& operator=( const ADS1015Controller& ) = delete;
+
+private:
 	Result< std::uint16_t > readConfig();
 
 	Result< void > writeConfig( std::uint16_t config );

--- a/code/source/i2c/BMP180Controller.hpp
+++ b/code/source/i2c/BMP180Controller.hpp
@@ -113,6 +113,10 @@ public:
 	[[nodiscard]] Result< float > getAbsoluteAltitude( float localPressure = kPressureAtSeaLevelPa );
 
 private:
+	BMP180Controller( const BMP180Controller& ) = delete;
+	BMP180Controller& operator=( const BMP180Controller& ) = delete;
+
+private:
 	SamplingAccuracy m_samplingAccuracy;
 	utils::FastPimpl< CalibrationConstants, kCalibConstSize, kCalibConstAlign > m_constants;
 };

--- a/code/source/i2c/LM75Controller.hpp
+++ b/code/source/i2c/LM75Controller.hpp
@@ -117,6 +117,10 @@ public:
 
 	/// Retrieves the temperature in Fahrenheit
 	[[nodiscard]] Result< float > getTemperatureF();
+
+private:
+	LM75Controller( const LM75Controller& ) = delete;
+	LM75Controller& operator=( const LM75Controller& ) = delete;
 };
 
 } // namespace v1

--- a/code/source/i2c/MPU6050Controller.hpp
+++ b/code/source/i2c/MPU6050Controller.hpp
@@ -123,6 +123,9 @@ private:
 	// really this should be done only once for each sensor module, and stored individually for
 	// the sensor (sort of calibration) as offsets.
 	void calculateImuError();
+
+	MPU6050Controller( const MPU6050Controller& ) = delete;
+	MPU6050Controller& operator=( const MPU6050Controller& ) = delete;
 };
 
 } // namespace v1

--- a/code/source/i2c/MPU9250Controller.hpp
+++ b/code/source/i2c/MPU9250Controller.hpp
@@ -115,6 +115,10 @@ public:
 
 	/// Retrieves the sensor's temperature in degrees Celsius.
 	// [[nodiscard]] Result< float > getTemperature();
+
+private:
+	MPU9250Controller( const MPU9250Controller& ) = delete;
+	MPU9250Controller& operator=( const MPU9250Controller& ) = delete;
 };
 
 } // namespace v1

--- a/code/source/i2c/PCA9685Controller.hpp
+++ b/code/source/i2c/PCA9685Controller.hpp
@@ -82,6 +82,10 @@ public:
 		// 1 step = 4.88 microseconds (20000us / 4096 steps for 50Hz)
 		return static_cast< std::uint16_t >( ( pulseWidth / 20'000.0f ) * pcaResolution );
 	}
+
+private:
+	PCA9685Controller( const PCA9685Controller& ) = delete;
+	PCA9685Controller& operator=( const PCA9685Controller& ) = delete;
 };
 
 } // namespace v1


### PR DESCRIPTION
Delete IC device copy ctors and copy assign operators, it doesn't make sense for them to be copyable, because they may have their own internal states, and if copied they would be using the I2C device, with a potential to mutate internal states.